### PR TITLE
3-3-4&3-3-5 編集機能と削除機能を実装する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,6 +12,13 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:id])
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   def create

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -21,6 +21,12 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
+  def destroy
+    task = Task.find(params[:id])
+    task.destroy
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+  end
+
   def create
     task = Task.new(task_params)
     task.save!

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,6 +15,12 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
   end
 
+  def create
+    task = Task.new(task_params)
+    task.save!
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+  end
+
   def update
     task = Task.find(params[:id])
     task.update!(task_params)
@@ -25,12 +31,6 @@ class TasksController < ApplicationController
     task = Task.find(params[:id])
     task.destroy
     redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
-  end
-
-  def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
   end
 
   private

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+  .form-group 
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group 
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,4 @@ h1 タスクの編集
 .nav.justify-content-end 
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group 
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group 
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+.nav.justify-content-end 
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group 
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group 
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,3 +16,4 @@ table.table.table-hover
           td= task.created_at
           td 
             = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
+            = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -8,8 +8,11 @@ table.table.table-hover
     tr 
       th= Task.human_attribute_name(:name)
       th= Task.human_attribute_name(:created_at)
+      th 
     tbody
       - @tasks.each do |task|
         tr 
           td= link_to task.name, task
           td= task.created_at
+          td 
+            = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav.justify-content-expand
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control',  id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -21,3 +21,4 @@ table.table.table-hover
       td= @task.updated_at
 
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,5 @@ table.table.table-hover
     tr 
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'


### PR DESCRIPTION
# 詳細

- 一覧画面に編集ボタンを表示
- 詳細画面に編集ボタンを表示
- 編集アクションを追加
- 編集画面のビューを実装
- パーシャルを使った新規登録画面と編集画面の共有化
- 一覧画面に削除ボタンを表示
- 詳細画面に削除ボタンを表示
- 削除アクションを実装

## その他修正

- createアクションの位置を移動

# 実行画面
![スクリーンショット 2022-02-09 午後1 54 01（2）](https://user-images.githubusercontent.com/98796994/153124983-d4817d44-1f6b-495f-ae5f-83d46a818264.png)
![スクリーンショット 2022-02-09 午後1 54 08（2）](https://user-images.githubusercontent.com/98796994/153124989-57b71738-a36f-4a78-98d7-82076e3aefcd.png)
![スクリーンショット 2022-02-09 午後1 54 11（2）](https://user-images.githubusercontent.com/98796994/153124991-e7818119-c215-46cf-81e1-b8fc46d9dda6.png)
![スクリーンショット 2022-02-09 午後1 54 20（2）](https://user-images.githubusercontent.com/98796994/153124992-fab1dbfc-ef27-46e9-b7f5-041d4d3810f3.png)
![スクリーンショット 2022-02-09 午後1 54 23（2）](https://user-images.githubusercontent.com/98796994/153124995-e67cec5b-3039-4e1b-8846-22422d391d1b.png)

