### PR TITLE
4-1 ~ 4-4 データの内容制限、検証とコールバック

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,9 +16,13 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+    @task = Task.new(task_params)
+
+    if @task.save
+      redirect_to @tasks, notice: "タスク「#{@task.name}」を登録しました。"
+    else
+      render :new
+    end
   end
 
   def update

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,4 @@
 class Task < ApplicationRecord
   validates :name, presence: true
+  validates :name, length: { maximum: 30 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,11 @@
 class Task < ApplicationRecord
   validates :name, presence: true
   validates :name, length: { maximum: 30 }
+  validate :validate_name_not_including_comma
+  
+  private
+
+  def validate_name_not_including_comma
+    errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
 end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,3 +1,8 @@
+- if task.errors.present?
+  ul#error_explanation 
+    - task.errors.full_messages.each do |message|
+      li= message 
+
 = form_with model: task, local: true do |f|
   .form-group 
     = f.label :name

--- a/db/migrate/20220209062200_change_tasks_name_not_null.rb
+++ b/db/migrate/20220209062200_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :tasks, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_051847) do
+ActiveRecord::Schema.define(version: 2022_02_09_062200) do
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 詳細

- NOT NULL制約を追加
- 名前を必須とする検証を追加 
- コントローラに検証エラー時の対応を追加　
- ビューに検証エラー時の対応を追加
- 名前を30字以下にする検証を追加
- 名前にカンマを含めない検証を追加

## 備考
以下２項目は後の工程のために実装していません
- 4-2-4　ユニークインデックスを作成する
- 4-4-2　コールバックの実装

## 実行画面
![スクリーンショット 2022-02-10 午前10 44 50（2）](https://user-images.githubusercontent.com/98796994/153321160-2cab9716-1b4d-4ab4-90bb-279926108cf3.png)

